### PR TITLE
Add `singleReturnOnly` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # eslint-plugin-prefer-arrow
-ESLint plugin to prefer arrow functions. By default, the plugin allows usage of `function` as a member of an Object's prototype, but this can be changed with the property `disallowPrototype`.
+ESLint plugin to prefer arrow functions. By default, the plugin allows usage of `function` as a member of an Object's prototype, but this can be changed with the property `disallowPrototype`. Alternatively, with the `singleReturnOnly` option, this plugin only reports functions where converting to an arrow function would dramatically simplify the code.
 
 # Installation
 
@@ -21,10 +21,13 @@ Add the plugin to the `plugins` section and the rule to the `rules` section in y
   "prefer-arrow/prefer-arrow-functions": [
      "warn",
      {
-       "disallowPrototype": true
+       "disallowPrototype": true,
+       "singleReturnOnly": false
      }
    ]
 ]
 ```
 # Configuration
-There is currently only one configuration option, `disallowPrototype`. If set to true, the plugin will warn if `function` is used anytime. Otherwise, the plugin allows usage of `function` if it is a member of an Object's prototype.
+ * `disallowPrototype`: If set to true, the plugin will warn if `function` is used anytime. Otherwise, the plugin allows usage of `function` if it is a member of an Object's prototype.
+ * `singleReturnOnly`: If set to true, the plugin will only warn for `function` declarations which *only* contain a return statement. These often look much better when declared as arrow functions without braces. Works well in conjunction with ESLint's built-in [arrow-body-style](http://eslint.org/docs/rules/arrow-body-style) set to `as-needed`.
+ 

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -18,6 +18,9 @@ module.exports = {
       properties: {
         disallowPrototype: {
           type: 'boolean'
+        },
+        singleReturnOnly: {
+          type: 'boolean'
         }
       },
       additionalProperties: false
@@ -64,11 +67,16 @@ const isConstructor = (node) => {
 const isNamed = (node) =>
   node.type === 'FunctionDeclaration' && node.id && node.id.name;
 
-const inspectNode = (node, context) => {  
-  const disallowPrototype = (context.options[0] || {}).disallowPrototype;
+const inspectNode = (node, context) => {
+  const opts = context.options[0] || {};
+  const disallowPrototype = opts.disallowPrototype;
+  const singleReturnOnly = opts.singleReturnOnly;
 
   if(isConstructor(node)) return;
-  if(disallowPrototype || !isPrototypeAssignment(node)) {
+  if (singleReturnOnly) {
+    if (node.body.body.length === 1 && node.body.body[0].type === 'ReturnStatement')
+      return context.report(node, 'Prefer using arrow functions over plain functions which only return a value');
+  } else if(disallowPrototype || !isPrototypeAssignment(node)) {
     return context.report(node, isNamed(node) ?
       'Use const or class constructors instead of named functions' :
       'Prefer using arrow functions over plain functions');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "eslint": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0"
+    "eslint": "^2.0.0 || ^3.0.0",
+    "mocha": "^3.4.1"
   },
   "keywords": [
     "eslint",

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const singleReturnOnly = code => ({code, options: [{singleReturnOnly: true}]});
+
 var rule = require('../../../lib/rules/prefer-arrow-functions'),
     RuleTester = require('eslint').RuleTester;
 
@@ -20,13 +22,30 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
     '["Hello", "World"].reduce((p, a) => p + " " + a);',
     'var foo = (...args) => args',
     'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};',
-    'class obj {constructor(foo){this.foo = foo;}}; obj.prototype = {func: function() {}};'
+    'class obj {constructor(foo){this.foo = foo;}}; obj.prototype = {func: function() {}};',
+    ...[
+        'var foo = (bar) => {return bar();}',
+        'function foo(bar) {bar()}',
+        'var x = function foo(bar) {bar()}',
+        'var x = function(bar) {bar()}',
+        'function foo(bar) {/* yo */ bar()}',
+        'function foo() {}',
+        'function foo(bar) {bar(); return bar()}',
+    ].map(singleReturnOnly)
   ],
   invalid: [
     {code: 'function foo() { return "Hello!"; }', errors: ['Use const or class constructors instead of named functions']},
     {code: 'function foo() { return arguments; }', errors: ['Use const or class constructors instead of named functions']},
     {code: 'var foo = function() { return "World"; }', errors: ['Prefer using arrow functions over plain functions']},
     {code: '["Hello", "World"].reduce(function(a, b) { return a + " " + b; })', errors: ['Prefer using arrow functions over plain functions']},
-    {code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};', errors: ['Prefer using arrow functions over plain functions'], options: [{disallowPrototype:true}]}
+    {code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};', errors: ['Prefer using arrow functions over plain functions'], options: [{disallowPrototype:true}]},
+    ...[
+        'function foo() { return 3; }',
+        'function foo(a) { return 3; }',
+        'var foo = function() { return "World"; }',
+        'var foo = function x() { return "World"; }',
+        'function foo(a) { /* yo */ return 3; }',
+        'function foo(a) { return a && (3 + a()) ? true : 99; }',
+    ].map(singleReturnOnly).map(testCase => Object.assign({errors: ['Prefer using arrow functions over plain functions which only return a value']}, testCase))
   ]
 });


### PR DESCRIPTION
This PR adds an option to only convert functions if they could be converted to brace-less arrow functions.