### PR TITLE
Support --fix for singleReturnOnly mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # eslint-plugin-prefer-arrow
-ESLint plugin to prefer arrow functions. By default, the plugin allows usage of `function` as a member of an Object's prototype, but this can be changed with the property `disallowPrototype`.
+ESLint plugin to prefer arrow functions. By default, the plugin allows usage of `function` as a member of an Object's prototype, but this can be changed with the property `disallowPrototype`. Alternatively, with the `singleReturnOnly` option, this plugin only reports functions where converting to an arrow function would dramatically simplify the code.
 
 # Installation
 
@@ -21,10 +21,13 @@ Add the plugin to the `plugins` section and the rule to the `rules` section in y
   "prefer-arrow/prefer-arrow-functions": [
      "warn",
      {
-       "disallowPrototype": true
+       "disallowPrototype": true,
+       "singleReturnOnly": false
      }
    ]
 ]
 ```
 # Configuration
-There is currently only one configuration option, `disallowPrototype`. If set to true, the plugin will warn if `function` is used anytime. Otherwise, the plugin allows usage of `function` if it is a member of an Object's prototype.
+ * `disallowPrototype`: If set to true, the plugin will warn if `function` is used anytime. Otherwise, the plugin allows usage of `function` if it is a member of an Object's prototype.
+ * `singleReturnOnly`: If set to true, the plugin will only warn for `function` declarations which *only* contain a return statement. These often look much better when declared as arrow functions without braces. Works well in conjunction with ESLint's built-in [arrow-body-style](http://eslint.org/docs/rules/arrow-body-style) set to `as-needed`.
+ 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Add the plugin to the `plugins` section and the rule to the `rules` section in y
      "warn",
      {
        "disallowPrototype": true,
-       "singleReturnOnly": false
+       "singleReturnOnly": false,
+       "classPropertiesAllowed": false
      }
    ]
 ]
@@ -30,4 +31,5 @@ Add the plugin to the `plugins` section and the rule to the `rules` section in y
 # Configuration
  * `disallowPrototype`: If set to true, the plugin will warn if `function` is used anytime. Otherwise, the plugin allows usage of `function` if it is a member of an Object's prototype.
  * `singleReturnOnly`: If set to true, the plugin will only warn for `function` declarations which *only* contain a return statement. These often look much better when declared as arrow functions without braces. Works well in conjunction with ESLint's built-in [arrow-body-style](http://eslint.org/docs/rules/arrow-body-style) set to `as-needed`.
+ * `classPropertiesAllowed`: (Only takes effect if `singleReturnOnly` is enabled) If set to true, the plugin will warn about functions which could be replaced with arrow functions defined as [class instance fields](https://github.com/jeffmo/es-class-static-properties-and-fields). Enable if you're using Babel's [transform-class-properties](https://babeljs.io/docs/plugins/transform-class-properties/) plugin.
  

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -127,21 +127,22 @@ let replaceTokens = function (origSource, tokens, replacements) {
   return result;
 };
 
-const tokenMatcher = (type, value) =>
-  token => token.type === type && token.value === value;
+const tokenMatcher = (type, value = undefined) =>
+  token => token.type === type && (typeof value === 'undefined' || token.value === value);
 
 function fixFunctionExpression(src, node) {
-  console.log("Fixing ", src.getText(node));
   const orig = src.getText();
   const tokens = src.getTokens(node);
   const bodyTokens = src.getTokens(node.body);
 
   let swap = {};
-  const functionKeywordToken = tokens.find(tokenMatcher('Keyword', 'function'));
-  swap[functionKeywordToken.start] = ['', true];
-  const nameToken = src.getTokenAfter(functionKeywordToken);
-  if (nameToken.type === 'Identifier') {
-    swap[nameToken.start] = [''];
+  const fnKeyword = tokens.find(tokenMatcher('Keyword', 'function'));
+  if (fnKeyword) {
+    swap[fnKeyword.start] = ['', true];
+    const nameToken = src.getTokenAfter(fnKeyword);
+    if (nameToken.type === 'Identifier') {
+      swap[nameToken.start] = [''];
+    }
   }
   swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=> ', true];
   const parens = node.body.body[0].argument.type === 'ObjectExpression';
@@ -153,7 +154,7 @@ function fixFunctionExpression(src, node) {
   const closeBraces = bodyTokens.filter(tokenMatcher('Punctuator', '}'));
   const lastCloseBrace = closeBraces[closeBraces.length - 1];
   swap[lastCloseBrace.start] = ['', false, true];
-  return replaceTokens(orig, tokens, swap).replace(/ $/, '') + (parens && !semicolons.length ? ')' : '');
+  return (fnKeyword ? '' : ' = ') + replaceTokens(orig, tokens, swap).replace(/ $/, '') + (parens && !semicolons.length ? ')' : '') + (fnKeyword ? '' : ';');
 }
 
 function fixFunctionDeclaration(src, node) {

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -18,6 +18,9 @@ module.exports = {
       properties: {
         disallowPrototype: {
           type: 'boolean'
+        },
+        singleReturnOnly: {
+          type: 'boolean'
         }
       },
       additionalProperties: false
@@ -64,11 +67,16 @@ const isConstructor = (node) => {
 const isNamed = (node) =>
   node.type === 'FunctionDeclaration' && node.id && node.id.name;
 
-const inspectNode = (node, context) => {  
-  const disallowPrototype = (context.options[0] || {}).disallowPrototype;
+const inspectNode = (node, context) => {
+  const opts = context.options[0] || {};
+  const disallowPrototype = opts.disallowPrototype;
+  const singleReturnOnly = opts.singleReturnOnly;
 
   if(isConstructor(node)) return;
-  if(disallowPrototype || !isPrototypeAssignment(node)) {
+  if (singleReturnOnly) {
+    if (node.body.body.length === 1 && node.body.body[0].type === 'ReturnStatement')
+      return context.report(node, 'Prefer using arrow functions over plain functions which only return a value');
+  } else if(disallowPrototype || !isPrototypeAssignment(node)) {
     return context.report(node, isNamed(node) ?
       'Use const or class constructors instead of named functions' :
       'Prefer using arrow functions over plain functions');

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -65,6 +65,12 @@ const isConstructor = (node) => {
 const isNamed = (node) =>
   node.type === 'FunctionDeclaration' && node.id && node.id.name;
 
+const functionOnlyContainsReturnStatement = node =>
+  node.body.body.length === 1 && node.body.body[0].type === 'ReturnStatement';
+
+const isNamedDefaultExport = node =>
+  node.id && node.id.name && node.parent.type === 'ExportDefaultDeclaration';
+
 const inspectNode = (node, context) => {
   const opts = context.options[0] || {};
   const disallowPrototype = opts.disallowPrototype;
@@ -72,7 +78,7 @@ const inspectNode = (node, context) => {
 
   if(isConstructor(node)) return;
   if (singleReturnOnly) {
-    if (node.body.body.length === 1 && node.body.body[0].type === 'ReturnStatement')
+    if (functionOnlyContainsReturnStatement(node) && !isNamedDefaultExport(node))
       return context.report({
         node,
         message: 'Prefer using arrow functions over plain functions which only return a value',

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -106,18 +106,19 @@ let replaceTokens = function (origSource, tokens, replacements) {
   for (const token of tokens) {
     if (lastTokenEnd >= 0) {
       let between = origSource.substring(lastTokenEnd, token.start);
-      if (removeNextLeadingSpace && between[0] === ' ') {
-        between = between.substring(1);
+      if (removeNextLeadingSpace) {
+        between = between.replace(/^\s+/, '');
       }
       result += between;
     }
     removeNextLeadingSpace = false;
     if (token.start in replacements) {
       const replaceInfo = replacements[token.start];
-      result += replaceInfo[0];
-      if (replaceInfo[1]) {
-        removeNextLeadingSpace = true;
+      if (replaceInfo[2]) {
+        result = result.replace(/\s+$/, '');
       }
+      result += replaceInfo[0];
+      removeNextLeadingSpace = !!replaceInfo[1];
     } else {
       result += origSource.substring(token.start, token.end);
     }
@@ -130,6 +131,7 @@ const tokenMatcher = (type, value) =>
   token => token.type === type && token.value === value;
 
 function fixFunctionExpression(src, node) {
+  console.log("Fixing ", src.getText(node));
   const orig = src.getText();
   const tokens = src.getTokens(node);
   const bodyTokens = src.getTokens(node.body);
@@ -141,7 +143,7 @@ function fixFunctionExpression(src, node) {
   if (nameToken.type === 'Identifier') {
     swap[nameToken.start] = [''];
   }
-  swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=>'];
+  swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=> ', true];
   const parens = node.body.body[0].argument.type === 'ObjectExpression';
   swap[bodyTokens.find(tokenMatcher('Keyword', 'return')).start] = [parens ? '(' : '', true];
   const semicolons = bodyTokens.filter(tokenMatcher('Punctuator', ';'));
@@ -149,7 +151,8 @@ function fixFunctionExpression(src, node) {
     swap[semicolons[semicolons.length - 1].start] = [parens ? ')' : '', true];
   }
   const closeBraces = bodyTokens.filter(tokenMatcher('Punctuator', '}'));
-  swap[closeBraces[closeBraces.length - 1].start] = [''];
+  const lastCloseBrace = closeBraces[closeBraces.length - 1];
+  swap[lastCloseBrace.start] = ['', false, true];
   return replaceTokens(orig, tokens, swap).replace(/ $/, '') + (parens && !semicolons.length ? ')' : '');
 }
 
@@ -158,16 +161,26 @@ function fixFunctionDeclaration(src, node) {
   const tokens = src.getTokens(node);
   const bodyTokens = src.getTokens(node.body);
   let swap = {};
+
+  const omitVar = node.parent && node.parent.type === 'ExportDefaultDeclaration';
   const parens = node.body.body[0].argument.type === 'ObjectExpression';
-  swap[tokens.find(tokenMatcher('Keyword', 'function')).start] = ['const'];
-  swap[tokens.find(tokenMatcher('Punctuator', '(')).start] = [' = ('];
-  swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=>'];
+  swap[tokens.find(tokenMatcher('Keyword', 'function')).start] = omitVar ? ['', true] : ['const'];
+  swap[tokens.find(tokenMatcher('Punctuator', '(')).start] = [omitVar ? '(' : ' = ('];
+  if (omitVar) {
+    const functionKeywordToken = tokens.find(tokenMatcher('Keyword', 'function'));
+    const nameToken = src.getTokenAfter(functionKeywordToken);
+    if (nameToken.type === 'Identifier') {
+      swap[nameToken.start] = [''];
+    }
+  }
+  swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=> ', true];
   swap[bodyTokens.find(tokenMatcher('Keyword', 'return')).start] = [parens ? '(' : '', true];
   const semicolons = bodyTokens.filter(tokenMatcher('Punctuator', ';'));
   if (semicolons.length) {
     swap[semicolons[semicolons.length-1].start] = [parens ? ')' : '', true];
   }
   const closeBraces = bodyTokens.filter(tokenMatcher('Punctuator', '}'));
-  swap[closeBraces[closeBraces.length-1].start] = [''];
+  const lastCloseBrace = closeBraces[closeBraces.length-1];
+  swap[lastCloseBrace.start] = ['', false, true];
   return replaceTokens(orig, tokens, swap).replace(/ $/, '') + (parens && !semicolons.length ? ');' : ';');
 }

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -125,45 +125,46 @@ let replaceTokens = function (origSource, tokens, replacements) {
   return result;
 };
 
+const tokenMatcher = (type, value) =>
+  token => token.type === type && token.value === value;
+
 function fixFunctionExpression(src, node) {
   const orig = src.getText();
   const tokens = src.getTokens(node);
-  let replacements = {};
-  const functionKeywordToken = tokens.find(token => token.type === 'Keyword' && token.value === 'function');
-  replacements[functionKeywordToken.start] = ['', true];
-  const tokenAfterFunctionKeyword = src.getTokenAfter(functionKeywordToken);
-  if (tokenAfterFunctionKeyword.type === 'Identifier') {
-    replacements[tokenAfterFunctionKeyword.start] = [`/*${tokenAfterFunctionKeyword.value}*/`];
+  const bodyTokens = src.getTokens(node.body);
+
+  let swap = {};
+  const functionKeywordToken = tokens.find(tokenMatcher('Keyword', 'function'));
+  swap[functionKeywordToken.start] = ['', true];
+  const nameToken = src.getTokenAfter(functionKeywordToken);
+  if (nameToken.type === 'Identifier') {
+    swap[nameToken.start] = [`/*${nameToken.value}*/`];
   }
-  replacements[src.getTokens(node.body).find(token => token.type === 'Punctuator' && token.value === '{').start] = ['=>'];
-  replacements[src.getTokens(node.body).find(token => token.type === 'Keyword' && token.value === 'return').start] = ['', true];
-  const semicolonsInReturn = src.getTokens(node.body).filter(token => token.type === 'Punctuator' && token.value === ';');
-  if (semicolonsInReturn.length) {
-    replacements[semicolonsInReturn[semicolonsInReturn.length - 1].start] = ['', true];
+  swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=>'];
+  swap[bodyTokens.find(tokenMatcher('Keyword', 'return')).start] = ['', true];
+  const semicolons = bodyTokens.filter(tokenMatcher('Punctuator', ';'));
+  if (semicolons.length) {
+    swap[semicolons[semicolons.length - 1].start] = ['', true];
   }
-  const closeBraces = src.getTokens(node.body).filter(token => token.type === 'Punctuator' && token.value === '}');
-  replacements[closeBraces[closeBraces.length - 1].start] = [''];
-  let newtext = replaceTokens(orig, tokens, replacements);
-  newtext = newtext.replace(/ $/, '');
-  return newtext;
+  const closeBraces = bodyTokens.filter(tokenMatcher('Punctuator', '}'));
+  swap[closeBraces[closeBraces.length - 1].start] = [''];
+  return replaceTokens(orig, tokens, swap).replace(/ $/, '');
 }
 
 function fixFunctionDeclaration(src, node) {
   const orig = src.getText();
   const tokens = src.getTokens(node);
-  let replacements = {};
-  replacements[tokens.find(token => token.type === 'Keyword' && token.value === 'function').start] = ['const'];
-  replacements[tokens.find(token => token.type === 'Punctuator' && token.value === '(').start] = [' = ('];
-  replacements[src.getTokens(node.body).find(token => token.type === 'Punctuator' && token.value === '{').start] = ['=>'];
-  replacements[src.getTokens(node.body).find(token => token.type === 'Keyword' && token.value === 'return').start] = ['', true];
-  const semicolonsInReturn = src.getTokens(node.body).filter(token => token.type === 'Punctuator' && token.value === ';');
+  const bodyTokens = src.getTokens(node.body);
+  let swap = {};
+  swap[tokens.find(tokenMatcher('Keyword', 'function')).start] = ['const'];
+  swap[tokens.find(tokenMatcher('Punctuator', '(')).start] = [' = ('];
+  swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=>'];
+  swap[bodyTokens.find(tokenMatcher('Keyword', 'return')).start] = ['', true];
+  const semicolonsInReturn = bodyTokens.filter(tokenMatcher('Punctuator', ';'));
   if (semicolonsInReturn.length) {
-    replacements[semicolonsInReturn[semicolonsInReturn.length-1].start] = ['', true];
+    swap[semicolonsInReturn[semicolonsInReturn.length-1].start] = ['', true];
   }
-  const closeBraces = src.getTokens(node.body).filter(token => token.type === 'Punctuator' && token.value === '}');
-  replacements[closeBraces[closeBraces.length-1].start] = [''];
-  let newtext = replaceTokens(orig, tokens, replacements);
-  newtext = newtext.replace(/ $/, '');
-  newtext += ';';
-  return newtext;
+  const closeBraces = bodyTokens.filter(tokenMatcher('Punctuator', '}'));
+  swap[closeBraces[closeBraces.length-1].start] = [''];
+  return replaceTokens(orig, tokens, swap).replace(/ $/, '') + ';';
 }

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -21,6 +21,9 @@ module.exports = {
         },
         singleReturnOnly: {
           type: 'boolean'
+        },
+        classPropertiesAllowed: {
+          type: 'boolean'
         }
       },
       additionalProperties: false
@@ -71,14 +74,14 @@ const functionOnlyContainsReturnStatement = node =>
 const isNamedDefaultExport = node =>
   node.id && node.id.name && node.parent.type === 'ExportDefaultDeclaration';
 
+const isClassMethod = node => node.parent.type === 'MethodDefinition';
+
 const inspectNode = (node, context) => {
   const opts = context.options[0] || {};
-  const disallowPrototype = opts.disallowPrototype;
-  const singleReturnOnly = opts.singleReturnOnly;
-
   if(isConstructor(node)) return;
-  if (singleReturnOnly) {
-    if (functionOnlyContainsReturnStatement(node) && !isNamedDefaultExport(node))
+  if (opts.singleReturnOnly) {
+    if (functionOnlyContainsReturnStatement(node) && !isNamedDefaultExport(node)
+        && (opts.classPropertiesAllowed || !isClassMethod(node)))
       return context.report({
         node,
         message: 'Prefer using arrow functions over plain functions which only return a value',
@@ -96,7 +99,7 @@ const inspectNode = (node, context) => {
           }
         }
       });
-  } else if(disallowPrototype || !isPrototypeAssignment(node)) {
+  } else if(opts.disallowPrototype || !isPrototypeAssignment(node)) {
     return context.report(node, isNamed(node) ?
         'Use const or class constructors instead of named functions' :
         'Prefer using arrow functions over plain functions');

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -137,12 +137,24 @@ function fixFunctionExpression(src, node) {
 
   let swap = {};
   const fnKeyword = tokens.find(tokenMatcher('Keyword', 'function'));
+  let prefix = '';
+  let suffix = '';
   if (fnKeyword) {
     swap[fnKeyword.start] = ['', true];
     const nameToken = src.getTokenAfter(fnKeyword);
     if (nameToken.type === 'Identifier') {
       swap[nameToken.start] = [''];
     }
+  } else if (node.parent.type === 'MethodDefinition') {
+    // The eslint Node starts with the parens, like
+    //    render() { return "hi"; }
+    //          ^--- node starts here
+    // We need to add equals sign after the method name to convert to instance property assignment
+    prefix = ' = ';
+    suffix = ';'
+  } else if (node.parent.type === 'Property') {
+    // Similar to above
+    prefix = ': ';
   }
   swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=> ', true];
   const parens = node.body.body[0].argument.type === 'ObjectExpression';
@@ -154,7 +166,7 @@ function fixFunctionExpression(src, node) {
   const closeBraces = bodyTokens.filter(tokenMatcher('Punctuator', '}'));
   const lastCloseBrace = closeBraces[closeBraces.length - 1];
   swap[lastCloseBrace.start] = ['', false, true];
-  return (fnKeyword ? '' : ' = ') + replaceTokens(orig, tokens, swap).replace(/ $/, '') + (parens && !semicolons.length ? ')' : '') + (fnKeyword ? '' : ';');
+  return prefix + replaceTokens(orig, tokens, swap).replace(/ $/, '') + (parens && !semicolons.length ? ')' : '') + suffix;
 }
 
 function fixFunctionDeclaration(src, node) {

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -26,12 +26,10 @@ module.exports = {
       additionalProperties: false
     }]
   },
-  create: function(context) {
-    return {
-      'FunctionDeclaration:exit': (node) => inspectNode(node, context),
-      'FunctionExpression:exit': (node) => inspectNode(node, context)
-    };
-  }
+  create: context => ({
+    'FunctionDeclaration:exit': (node) => inspectNode(node, context),
+    'FunctionExpression:exit': (node) => inspectNode(node, context)
+  })
 }
 
 const isPrototypeAssignment = (node) => {
@@ -99,7 +97,7 @@ const inspectNode = (node, context) => {
   }
 }
 
-const replaceTokens = function (origSource, tokens, replacements) {
+const replaceTokens = (origSource, tokens, replacements) => {
   let removeNextLeadingSpace = false;
   let result = '';
   let lastTokenEnd = -1;

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -79,16 +79,17 @@ const inspectNode = (node, context) => {
         node,
         message: 'Prefer using arrow functions over plain functions which only return a value',
         fix(fixer) {
-          let result;
           const src = context.getSourceCode();
-
+          let newText = null;
           if (node.type === 'FunctionDeclaration') {
-            result = fixer.replaceText(node, fixFunctionDeclaration(src, node));
+            newText = fixFunctionDeclaration(src, node);
 
           } else if (node.type === 'FunctionExpression') {
-            result = fixer.replaceText(node, fixFunctionExpression(src, node));
+            newText = fixFunctionExpression(src, node);
           }
-          return result;
+          if (newText !== null) {
+            return fixer.replaceText(node, newText)
+          }
         }
       });
   } else if(disallowPrototype || !isPrototypeAssignment(node)) {
@@ -138,17 +139,18 @@ function fixFunctionExpression(src, node) {
   swap[functionKeywordToken.start] = ['', true];
   const nameToken = src.getTokenAfter(functionKeywordToken);
   if (nameToken.type === 'Identifier') {
-    swap[nameToken.start] = [`/*${nameToken.value}*/`];
+    swap[nameToken.start] = [''];
   }
   swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=>'];
-  swap[bodyTokens.find(tokenMatcher('Keyword', 'return')).start] = ['', true];
+  const parens = node.body.body[0].argument.type === 'ObjectExpression';
+  swap[bodyTokens.find(tokenMatcher('Keyword', 'return')).start] = [parens ? '(' : '', true];
   const semicolons = bodyTokens.filter(tokenMatcher('Punctuator', ';'));
   if (semicolons.length) {
-    swap[semicolons[semicolons.length - 1].start] = ['', true];
+    swap[semicolons[semicolons.length - 1].start] = [parens ? ')' : '', true];
   }
   const closeBraces = bodyTokens.filter(tokenMatcher('Punctuator', '}'));
   swap[closeBraces[closeBraces.length - 1].start] = [''];
-  return replaceTokens(orig, tokens, swap).replace(/ $/, '');
+  return replaceTokens(orig, tokens, swap).replace(/ $/, '') + (parens && !semicolons.length ? ')' : '');
 }
 
 function fixFunctionDeclaration(src, node) {
@@ -156,15 +158,16 @@ function fixFunctionDeclaration(src, node) {
   const tokens = src.getTokens(node);
   const bodyTokens = src.getTokens(node.body);
   let swap = {};
+  const parens = node.body.body[0].argument.type === 'ObjectExpression';
   swap[tokens.find(tokenMatcher('Keyword', 'function')).start] = ['const'];
   swap[tokens.find(tokenMatcher('Punctuator', '(')).start] = [' = ('];
   swap[bodyTokens.find(tokenMatcher('Punctuator', '{')).start] = ['=>'];
-  swap[bodyTokens.find(tokenMatcher('Keyword', 'return')).start] = ['', true];
-  const semicolonsInReturn = bodyTokens.filter(tokenMatcher('Punctuator', ';'));
-  if (semicolonsInReturn.length) {
-    swap[semicolonsInReturn[semicolonsInReturn.length-1].start] = ['', true];
+  swap[bodyTokens.find(tokenMatcher('Keyword', 'return')).start] = [parens ? '(' : '', true];
+  const semicolons = bodyTokens.filter(tokenMatcher('Punctuator', ';'));
+  if (semicolons.length) {
+    swap[semicolons[semicolons.length-1].start] = [parens ? ')' : '', true];
   }
   const closeBraces = bodyTokens.filter(tokenMatcher('Punctuator', '}'));
   swap[closeBraces[closeBraces.length-1].start] = [''];
-  return replaceTokens(orig, tokens, swap).replace(/ $/, '') + ';';
+  return replaceTokens(orig, tokens, swap).replace(/ $/, '') + (parens && !semicolons.length ? ');' : ';');
 }

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -40,7 +40,7 @@ const isPrototypeAssignment = (node) => {
   while(parent) {
     switch(parent.type) {
       case 'MemberExpression':
-        if(parent.property && parent.property.name === 'prototype') 
+        if(parent.property && parent.property.name === 'prototype')
           return true;
         parent = parent.object;
         break;
@@ -51,7 +51,7 @@ const isPrototypeAssignment = (node) => {
       case 'ObjectExpression':
         parent = parent.parent;
         break;
-      default: 
+      default:
         return false;
     }
   }
@@ -75,10 +75,95 @@ const inspectNode = (node, context) => {
   if(isConstructor(node)) return;
   if (singleReturnOnly) {
     if (node.body.body.length === 1 && node.body.body[0].type === 'ReturnStatement')
-      return context.report(node, 'Prefer using arrow functions over plain functions which only return a value');
+      return context.report({
+        node,
+        message: 'Prefer using arrow functions over plain functions which only return a value',
+        fix(fixer) {
+          let result;
+          const src = context.getSourceCode();
+
+          if (node.type === 'FunctionDeclaration') {
+            result = fixer.replaceText(node, fixFunctionDeclaration(src, node));
+
+          } else if (node.type === 'FunctionExpression') {
+            result = fixer.replaceText(node, fixFunctionExpression(src, node));
+          }
+          return result;
+        }
+      });
   } else if(disallowPrototype || !isPrototypeAssignment(node)) {
     return context.report(node, isNamed(node) ?
-      'Use const or class constructors instead of named functions' :
-      'Prefer using arrow functions over plain functions');
+        'Use const or class constructors instead of named functions' :
+        'Prefer using arrow functions over plain functions');
   }
+}
+
+let replaceTokens = function (origSource, tokens, replacements) {
+  let removeNextLeadingSpace = false;
+  let result = '';
+  let lastTokenEnd = -1;
+  for (const token of tokens) {
+    if (lastTokenEnd >= 0) {
+      let between = origSource.substring(lastTokenEnd, token.start);
+      if (removeNextLeadingSpace && between[0] === ' ') {
+        between = between.substring(1);
+      }
+      result += between;
+    }
+    removeNextLeadingSpace = false;
+    if (token.start in replacements) {
+      const replaceInfo = replacements[token.start];
+      result += replaceInfo[0];
+      if (replaceInfo[1]) {
+        removeNextLeadingSpace = true;
+      }
+    } else {
+      result += origSource.substring(token.start, token.end);
+    }
+    lastTokenEnd = token.end;
+  }
+  return result;
+};
+
+function fixFunctionExpression(src, node) {
+  const orig = src.getText();
+  const tokens = src.getTokens(node);
+  let replacements = {};
+  const functionKeywordToken = tokens.find(token => token.type === 'Keyword' && token.value === 'function');
+  replacements[functionKeywordToken.start] = ['', true];
+  const tokenAfterFunctionKeyword = src.getTokenAfter(functionKeywordToken);
+  if (tokenAfterFunctionKeyword.type === 'Identifier') {
+    replacements[tokenAfterFunctionKeyword.start] = [`/*${tokenAfterFunctionKeyword.value}*/`];
+  }
+  replacements[src.getTokens(node.body).find(token => token.type === 'Punctuator' && token.value === '{').start] = ['=>'];
+  replacements[src.getTokens(node.body).find(token => token.type === 'Keyword' && token.value === 'return').start] = ['', true];
+  const semicolonsInReturn = src.getTokens(node.body).filter(token => token.type === 'Punctuator' && token.value === ';');
+  if (semicolonsInReturn.length) {
+    replacements[semicolonsInReturn[semicolonsInReturn.length - 1].start] = ['', true];
+  }
+  const closeBraces = src.getTokens(node.body).filter(token => token.type === 'Punctuator' && token.value === '}');
+  replacements[closeBraces[closeBraces.length - 1].start] = [''];
+  let newtext = replaceTokens(orig, tokens, replacements);
+  newtext = newtext.replace(/ $/, '');
+  return newtext;
+}
+
+function fixFunctionDeclaration(src, node) {
+  const orig = src.getText();
+  const tokens = src.getTokens(node);
+  let replacements = {};
+  replacements[tokens.find(token => token.type === 'Keyword' && token.value === 'function').start] = ['const'];
+  replacements[tokens.find(token => token.type === 'Punctuator' && token.value === '(').start] = [' = ('];
+  replacements[src.getTokens(node.body).find(token => token.type === 'Punctuator' && token.value === '{').start] = ['=>'];
+  replacements[src.getTokens(node.body).find(token => token.type === 'Keyword' && token.value === 'return').start] = ['', true];
+  const semicolonsInReturn = src.getTokens(node.body).filter(token => token.type === 'Punctuator' && token.value === ';');
+  if (semicolonsInReturn.length) {
+    replacements[semicolonsInReturn[semicolonsInReturn.length-1].start] = ['', true];
+  }
+  const closeBraces = src.getTokens(node.body).filter(token => token.type === 'Punctuator' && token.value === '}');
+  replacements[closeBraces[closeBraces.length-1].start] = [''];
+  let newtext = replaceTokens(orig, tokens, replacements);
+  newtext = newtext.replace(/ $/, '');
+  newtext += ';';
+  return newtext;
 }

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -99,7 +99,7 @@ const inspectNode = (node, context) => {
   }
 }
 
-let replaceTokens = function (origSource, tokens, replacements) {
+const replaceTokens = function (origSource, tokens, replacements) {
   let removeNextLeadingSpace = false;
   let result = '';
   let lastTokenEnd = -1;
@@ -130,7 +130,7 @@ let replaceTokens = function (origSource, tokens, replacements) {
 const tokenMatcher = (type, value = undefined) =>
   token => token.type === type && (typeof value === 'undefined' || token.value === value);
 
-function fixFunctionExpression(src, node) {
+const fixFunctionExpression = (src, node) => {
   const orig = src.getText();
   const tokens = src.getTokens(node);
   const bodyTokens = src.getTokens(node.body);
@@ -169,7 +169,7 @@ function fixFunctionExpression(src, node) {
   return prefix + replaceTokens(orig, tokens, swap).replace(/ $/, '') + (parens && !semicolons.length ? ')' : '') + suffix;
 }
 
-function fixFunctionDeclaration(src, node) {
+const fixFunctionDeclaration = (src, node) => {
   const orig = src.getText();
   const tokens = src.getTokens(node);
   const bodyTokens = src.getTokens(node.body);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "eslint": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0"
+    "eslint": "^2.0.0 || ^3.0.0",
+    "mocha": "^3.4.1"
   },
   "keywords": [
     "eslint",

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -40,14 +40,18 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
     {code: '["Hello", "World"].reduce(function(a, b) { return a + " " + b; })', errors: ['Prefer using arrow functions over plain functions']},
     {code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};', errors: ['Prefer using arrow functions over plain functions'], options: [{disallowPrototype:true}]},
     ...[
-      //TODO: export default function() {}
-      //TODO: closing brace on its own line
       ['function foo() { return 3; }', 'const foo = () => 3;'],
+      ['export default function() { return 3; }', 'export default () => 3;'],
+      ['export default function xyz() { return 3; }', 'export default () => 3;'],
         ['function foo(a) { return 3 }', 'const foo = (a) => 3;'],
+        ['function foo(a) {\n  return 3;\n}', 'const foo = (a) => 3;'],
+        ['function foo(a) {\n  return 3\n}', 'const foo = (a) => 3;'],
         ['function foo(a) { return 3; }', 'const foo = (a) => 3;'],
         ['function foo(a) { return {a: false}; }', 'const foo = (a) => ({a: false});'],
         ['function foo(a) { return {a: false} }', 'const foo = (a) => ({a: false});'],
         ['var foo = function() { return "World"; }', 'var foo = () => "World"'],
+        ['var foo = function() {\n  return "World";\n}', 'var foo = () => "World"'],
+        ['var foo = function() {\n  return "World"\n}', 'var foo = () => "World"'],
         ['var foo = function() { return {a: false} }', 'var foo = () => ({a: false})'],
         ['var foo = function() { return {a: false}; }', 'var foo = () => ({a: false})'],
         ['var foo = function() { return "World"; };', 'var foo = () => "World";'],
@@ -56,17 +60,18 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
         ['var foo = function () { return () => false }', 'var foo = () => () => false'],
         [
           '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*/function/*8*/ /*9*/x/*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/{/*17*/ /*18*/return/*19*/ /*20*/false/*21*/;/*22*/ /*23*/}/*24*/;/*25*/',
-          '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*//*8*/ /*9*//*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/=>/*17*/ /*18*//*19*/ /*20*/false/*21*//*22*/ /*23*//*24*/;/*25*/',
+          '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*//*8*/ /*9*//*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/=> /*17*/ /*18*//*19*/ /*20*/false/*21*//*22*/ /*23*//*24*/;/*25*/',
         ],
         [
           '/*1*/function/*2*/ /*3*/foo/*4*/(/*5*/a/*6*/)/*7*/ /*8*/\{/*9*/ /*10*/return/*11*/ /*12*/false/*13*/;/*14*/ /*15*/}/*16*/',
-          '/*1*/const/*2*/ /*3*/foo/*4*/ = (/*5*/a/*6*/)/*7*/ /*8*/=>/*9*/ /*10*//*11*/ /*12*/false/*13*//*14*/ /*15*/;/*16*/'
+          '/*1*/const/*2*/ /*3*/foo/*4*/ = (/*5*/a/*6*/)/*7*/ /*8*/=> /*9*/ /*10*//*11*/ /*12*/false/*13*//*14*/ /*15*/;/*16*/'
         ],
         ['function foo(a) { return a && (3 + a()) ? true : 99; }', 'const foo = (a) => a && (3 + a()) ? true : 99;'],
     ].map(io => Object.assign(
       {
         errors: ['Prefer using arrow functions over plain functions which only return a value'],
-        output: io[1]
+        output: io[1],
+        parserOptions: {sourceType: 'module'}
       },
       singleReturnOnly(io[0])
     ))

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const singleReturnOnly = code => ({code, options: [{singleReturnOnly: true}]});
+
 var rule = require('../../../lib/rules/prefer-arrow-functions'),
     RuleTester = require('eslint').RuleTester;
 
@@ -20,13 +22,30 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
     '["Hello", "World"].reduce((p, a) => p + " " + a);',
     'var foo = (...args) => args',
     'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};',
-    'class obj {constructor(foo){this.foo = foo;}}; obj.prototype = {func: function() {}};'
+    'class obj {constructor(foo){this.foo = foo;}}; obj.prototype = {func: function() {}};',
+    ...[
+        'var foo = (bar) => {return bar();}',
+        'function foo(bar) {bar()}',
+        'var x = function foo(bar) {bar()}',
+        'var x = function(bar) {bar()}',
+        'function foo(bar) {/* yo */ bar()}',
+        'function foo() {}',
+        'function foo(bar) {bar(); return bar()}',
+    ].map(singleReturnOnly)
   ],
   invalid: [
     {code: 'function foo() { return "Hello!"; }', errors: ['Use const or class constructors instead of named functions']},
     {code: 'function foo() { return arguments; }', errors: ['Use const or class constructors instead of named functions']},
     {code: 'var foo = function() { return "World"; }', errors: ['Prefer using arrow functions over plain functions']},
     {code: '["Hello", "World"].reduce(function(a, b) { return a + " " + b; })', errors: ['Prefer using arrow functions over plain functions']},
-    {code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};', errors: ['Prefer using arrow functions over plain functions'], options: [{disallowPrototype:true}]}
+    {code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};', errors: ['Prefer using arrow functions over plain functions'], options: [{disallowPrototype:true}]},
+    ...[
+        'function foo() { return 3; }',
+        'function foo(a) { return 3; }',
+        'var foo = function() { return "World"; }',
+        'var foo = function x() { return "World"; }',
+        'function foo(a) { /* yo */ return 3; }',
+        'function foo(a) { return a && (3 + a()) ? true : 99; }',
+    ].map(singleReturnOnly).map(testCase => Object.assign({errors: ['Prefer using arrow functions over plain functions which only return a value']}, testCase))
   ]
 });

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -36,7 +36,8 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
       'function foo() {}',
       'function foo(bar) {bar(); return bar()}',
       'class MyClass { foo(bar) {bar(); return bar()} }',
-      'var MyClass = { foo(bar) {bar(); return bar()} }'
+      'var MyClass = { foo(bar) {bar(); return bar()} }',
+      'export default function xyz() { return 3; }'
     ].map(singleReturnOnly)
   ],
   invalid: [
@@ -57,7 +58,6 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
 
       // Eslint treats export default as a special form of function declaration
       ['export default function() { return 3; }', 'export default () => 3;'],
-      ['export default function xyz() { return 3; }', 'export default () => 3;'],
 
       // Sanity check - make sure complex logic works
       ['function foo(a) { return a && (3 + a()) ? true : 99; }', 'const foo = (a) => a && (3 + a()) ? true : 99;'],

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -58,6 +58,7 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
         ['var foo = function x() { return "World"; };', 'var foo = () => "World";'],
         ['var foo = function () { return function(a) { a() } }', 'var foo = () => function(a) { a() }'],
         ['var foo = function () { return () => false }', 'var foo = () => () => false'],
+        ['class MyClass { render(a, b) { return 3; } }', 'class MyClass { render = (a, b) => 3; }'],
         [
           '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*/function/*8*/ /*9*/x/*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/{/*17*/ /*18*/return/*19*/ /*20*/false/*21*/;/*22*/ /*23*/}/*24*/;/*25*/',
           '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*//*8*/ /*9*//*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/=> /*17*/ /*18*//*19*/ /*20*/false/*21*//*22*/ /*23*//*24*/;/*25*/',

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -5,7 +5,11 @@
 
 'use strict';
 
-const singleReturnOnly = code => ({code, options: [{singleReturnOnly: true}], parserOptions: {sourceType: 'module'}});
+const singleReturnOnly = code => ({
+  code,
+  options: [{singleReturnOnly: true}],
+  parserOptions: {sourceType: 'module'}
+});
 
 var rule = require('../../../lib/rules/prefer-arrow-functions'),
     RuleTester = require('eslint').RuleTester;

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -40,19 +40,24 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
     {code: '["Hello", "World"].reduce(function(a, b) { return a + " " + b; })', errors: ['Prefer using arrow functions over plain functions']},
     {code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};', errors: ['Prefer using arrow functions over plain functions'], options: [{disallowPrototype:true}]},
     ...[
-        ['function foo() { return 3; }', 'const foo = () => 3;'],
+      //TODO: export default function() {}
+      //TODO: closing brace on its own line
+      ['function foo() { return 3; }', 'const foo = () => 3;'],
         ['function foo(a) { return 3 }', 'const foo = (a) => 3;'],
         ['function foo(a) { return 3; }', 'const foo = (a) => 3;'],
+        ['function foo(a) { return {a: false}; }', 'const foo = (a) => ({a: false});'],
+        ['function foo(a) { return {a: false} }', 'const foo = (a) => ({a: false});'],
         ['var foo = function() { return "World"; }', 'var foo = () => "World"'],
+        ['var foo = function() { return {a: false} }', 'var foo = () => ({a: false})'],
+        ['var foo = function() { return {a: false}; }', 'var foo = () => ({a: false})'],
         ['var foo = function() { return "World"; };', 'var foo = () => "World";'],
-        ['var foo = function x() { return "World"; };', 'var foo = /*x*/() => "World";'],
+        ['var foo = function x() { return "World"; };', 'var foo = () => "World";'],
         ['var foo = function () { return function(a) { a() } }', 'var foo = () => function(a) { a() }'],
         ['var foo = function () { return () => false }', 'var foo = () => () => false'],
         [
           '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*/function/*8*/ /*9*/x/*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/{/*17*/ /*18*/return/*19*/ /*20*/false/*21*/;/*22*/ /*23*/}/*24*/;/*25*/',
-          '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*//*8*/ /*9*//*x*//*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/=>/*17*/ /*18*//*19*/ /*20*/false/*21*//*22*/ /*23*//*24*/;/*25*/',
+          '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*//*8*/ /*9*//*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/=>/*17*/ /*18*//*19*/ /*20*/false/*21*//*22*/ /*23*//*24*/;/*25*/',
         ],
-        //TODO: nested function
         [
           '/*1*/function/*2*/ /*3*/foo/*4*/(/*5*/a/*6*/)/*7*/ /*8*/\{/*9*/ /*10*/return/*11*/ /*12*/false/*13*/;/*14*/ /*15*/}/*16*/',
           '/*1*/const/*2*/ /*3*/foo/*4*/ = (/*5*/a/*6*/)/*7*/ /*8*/=>/*9*/ /*10*//*11*/ /*12*/false/*13*//*14*/ /*15*/;/*16*/'

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const singleReturnOnly = code => ({code, options: [{singleReturnOnly: true}]});
+const singleReturnOnly = code => ({code, options: [{singleReturnOnly: true}], parserOptions: {sourceType: 'module'}});
 
 var rule = require('../../../lib/rules/prefer-arrow-functions'),
     RuleTester = require('eslint').RuleTester;
@@ -24,13 +24,15 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
     'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};',
     'class obj {constructor(foo){this.foo = foo;}}; obj.prototype = {func: function() {}};',
     ...[
-        'var foo = (bar) => {return bar();}',
-        'function foo(bar) {bar()}',
-        'var x = function foo(bar) {bar()}',
-        'var x = function(bar) {bar()}',
-        'function foo(bar) {/* yo */ bar()}',
-        'function foo() {}',
-        'function foo(bar) {bar(); return bar()}',
+      'var foo = (bar) => {return bar();}',
+      'function foo(bar) {bar()}',
+      'var x = function foo(bar) {bar()}',
+      'var x = function(bar) {bar()}',
+      'function foo(bar) {/* yo */ bar()}',
+      'function foo() {}',
+      'function foo(bar) {bar(); return bar()}',
+      'class MyClass { foo(bar) {bar(); return bar()} }',
+      'var MyClass = { foo(bar) {bar(); return bar()} }'
     ].map(singleReturnOnly)
   ],
   invalid: [
@@ -40,41 +42,56 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
     {code: '["Hello", "World"].reduce(function(a, b) { return a + " " + b; })', errors: ['Prefer using arrow functions over plain functions']},
     {code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};', errors: ['Prefer using arrow functions over plain functions'], options: [{disallowPrototype:true}]},
     ...[
+      // Make sure it works with ES6 classes & functions declared in object literals
+      ['class MyClass { render(a, b) { return 3; } }', 'class MyClass { render = (a, b) => 3; }'],
+      ['var MyClass = { render(a, b) { return 3; }, b: false }', 'var MyClass = { render: (a, b) => 3, b: false }'],
+
+      // Make sure named function declarations work
       ['function foo() { return 3; }', 'const foo = () => 3;'],
+      ['function foo(a) { return 3 }', 'const foo = (a) => 3;'],
+      ['function foo(a) { return 3; }', 'const foo = (a) => 3;'],
+
+      // Eslint treats export default as a special form of function declaration
       ['export default function() { return 3; }', 'export default () => 3;'],
       ['export default function xyz() { return 3; }', 'export default () => 3;'],
-        ['function foo(a) { return 3 }', 'const foo = (a) => 3;'],
-        ['function foo(a) {\n  return 3;\n}', 'const foo = (a) => 3;'],
-        ['function foo(a) {\n  return 3\n}', 'const foo = (a) => 3;'],
-        ['function foo(a) { return 3; }', 'const foo = (a) => 3;'],
-        ['function foo(a) { return {a: false}; }', 'const foo = (a) => ({a: false});'],
-        ['function foo(a) { return {a: false} }', 'const foo = (a) => ({a: false});'],
-        ['var foo = function() { return "World"; }', 'var foo = () => "World"'],
-        ['var foo = function() {\n  return "World";\n}', 'var foo = () => "World"'],
-        ['var foo = function() {\n  return "World"\n}', 'var foo = () => "World"'],
-        ['var foo = function() { return {a: false} }', 'var foo = () => ({a: false})'],
-        ['var foo = function() { return {a: false}; }', 'var foo = () => ({a: false})'],
-        ['var foo = function() { return "World"; };', 'var foo = () => "World";'],
-        ['var foo = function x() { return "World"; };', 'var foo = () => "World";'],
-        ['var foo = function () { return function(a) { a() } }', 'var foo = () => function(a) { a() }'],
-        ['var foo = function () { return () => false }', 'var foo = () => () => false'],
-        ['class MyClass { render(a, b) { return 3; } }', 'class MyClass { render = (a, b) => 3; }'],
-        [
-          '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*/function/*8*/ /*9*/x/*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/{/*17*/ /*18*/return/*19*/ /*20*/false/*21*/;/*22*/ /*23*/}/*24*/;/*25*/',
-          '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*//*8*/ /*9*//*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/=> /*17*/ /*18*//*19*/ /*20*/false/*21*//*22*/ /*23*//*24*/;/*25*/',
-        ],
-        [
-          '/*1*/function/*2*/ /*3*/foo/*4*/(/*5*/a/*6*/)/*7*/ /*8*/\{/*9*/ /*10*/return/*11*/ /*12*/false/*13*/;/*14*/ /*15*/}/*16*/',
-          '/*1*/const/*2*/ /*3*/foo/*4*/ = (/*5*/a/*6*/)/*7*/ /*8*/=> /*9*/ /*10*//*11*/ /*12*/false/*13*//*14*/ /*15*/;/*16*/'
-        ],
-        ['function foo(a) { return a && (3 + a()) ? true : 99; }', 'const foo = (a) => a && (3 + a()) ? true : 99;'],
-    ].map(io => Object.assign(
+
+      // Sanity check - make sure complex logic works
+      ['function foo(a) { return a && (3 + a()) ? true : 99; }', 'const foo = (a) => a && (3 + a()) ? true : 99;'],
+
+      // Make sure function expressions work
+      ['var foo = function() { return "World"; }', 'var foo = () => "World"'],
+      ['var foo = function() { return "World"; };', 'var foo = () => "World";'],
+      ['var foo = function x() { return "World"; };', 'var foo = () => "World";'],
+
+      // Make sure we wrap object literal returns in parens
+      ['var foo = function() { return {a: false} }', 'var foo = () => ({a: false})'],
+      ['var foo = function() { return {a: false}; }', 'var foo = () => ({a: false})'],
+      ['function foo(a) { return {a: false}; }', 'const foo = (a) => ({a: false});'],
+      ['function foo(a) { return {a: false} }', 'const foo = (a) => ({a: false});'],
+
+      // Make sure we treat inner functions properly
+      ['var foo = function () { return function(a) { a() } }', 'var foo = () => function(a) { a() }'],
+      ['var foo = function () { return () => false }', 'var foo = () => () => false'],
+
+      // Make sure we don't obliterate comments/whitespace and only remove newlines when appropriate
+      ['var foo = function() {\n  return "World";\n}', 'var foo = () => "World"'],
+      ['var foo = function() {\n  return "World"\n}', 'var foo = () => "World"'],
+      ['function foo(a) {\n  return 3;\n}', 'const foo = (a) => 3;'],
+      ['function foo(a) {\n  return 3\n}', 'const foo = (a) => 3;'],
+      [
+        '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*/function/*8*/ /*9*/x/*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/{/*17*/ /*18*/return/*19*/ /*20*/false/*21*/;/*22*/ /*23*/}/*24*/;/*25*/',
+        '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*//*8*/ /*9*//*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/=> /*17*/ /*18*//*19*/ /*20*/false/*21*//*22*/ /*23*//*24*/;/*25*/',
+      ],
+      [
+        '/*1*/function/*2*/ /*3*/foo/*4*/(/*5*/a/*6*/)/*7*/ /*8*/\{/*9*/ /*10*/return/*11*/ /*12*/false/*13*/;/*14*/ /*15*/}/*16*/',
+        '/*1*/const/*2*/ /*3*/foo/*4*/ = (/*5*/a/*6*/)/*7*/ /*8*/=> /*9*/ /*10*//*11*/ /*12*/false/*13*//*14*/ /*15*/;/*16*/'
+      ]
+    ].map(inputOutput => Object.assign(
       {
         errors: ['Prefer using arrow functions over plain functions which only return a value'],
-        output: io[1],
-        parserOptions: {sourceType: 'module'}
+        output: inputOutput[1]
       },
-      singleReturnOnly(io[0])
+      singleReturnOnly(inputOutput[0])
     ))
   ]
 });

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -40,12 +40,30 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
     {code: '["Hello", "World"].reduce(function(a, b) { return a + " " + b; })', errors: ['Prefer using arrow functions over plain functions']},
     {code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};', errors: ['Prefer using arrow functions over plain functions'], options: [{disallowPrototype:true}]},
     ...[
-        'function foo() { return 3; }',
-        'function foo(a) { return 3; }',
-        'var foo = function() { return "World"; }',
-        'var foo = function x() { return "World"; }',
-        'function foo(a) { /* yo */ return 3; }',
-        'function foo(a) { return a && (3 + a()) ? true : 99; }',
-    ].map(singleReturnOnly).map(testCase => Object.assign({errors: ['Prefer using arrow functions over plain functions which only return a value']}, testCase))
+        ['function foo() { return 3; }', 'const foo = () => 3;'],
+        ['function foo(a) { return 3 }', 'const foo = (a) => 3;'],
+        ['function foo(a) { return 3; }', 'const foo = (a) => 3;'],
+        ['var foo = function() { return "World"; }', 'var foo = () => "World"'],
+        ['var foo = function() { return "World"; };', 'var foo = () => "World";'],
+        ['var foo = function x() { return "World"; };', 'var foo = /*x*/() => "World";'],
+        ['var foo = function () { return function(a) { a() } }', 'var foo = () => function(a) { a() }'],
+        ['var foo = function () { return () => false }', 'var foo = () => () => false'],
+        [
+          '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*/function/*8*/ /*9*/x/*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/{/*17*/ /*18*/return/*19*/ /*20*/false/*21*/;/*22*/ /*23*/}/*24*/;/*25*/',
+          '/*1*/var/*2*/ /*3*/foo/*4*/ /*5*/=/*6*/ /*7*//*8*/ /*9*//*x*//*10*/(/*11*/a/*12*/, /*13*/b/*14*/)/*15*/ /*16*/=>/*17*/ /*18*//*19*/ /*20*/false/*21*//*22*/ /*23*//*24*/;/*25*/',
+        ],
+        //TODO: nested function
+        [
+          '/*1*/function/*2*/ /*3*/foo/*4*/(/*5*/a/*6*/)/*7*/ /*8*/\{/*9*/ /*10*/return/*11*/ /*12*/false/*13*/;/*14*/ /*15*/}/*16*/',
+          '/*1*/const/*2*/ /*3*/foo/*4*/ = (/*5*/a/*6*/)/*7*/ /*8*/=>/*9*/ /*10*//*11*/ /*12*/false/*13*//*14*/ /*15*/;/*16*/'
+        ],
+        ['function foo(a) { return a && (3 + a()) ? true : 99; }', 'const foo = (a) => a && (3 + a()) ? true : 99;'],
+    ].map(io => Object.assign(
+      {
+        errors: ['Prefer using arrow functions over plain functions which only return a value'],
+        output: io[1]
+      },
+      singleReturnOnly(io[0])
+    ))
   ]
 });

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -5,9 +5,9 @@
 
 'use strict';
 
-const singleReturnOnly = code => ({
+const singleReturnOnly = (code, extraRuleOptions) => ({
   code,
-  options: [{singleReturnOnly: true}],
+  options: [Object.assign({singleReturnOnly: true}, extraRuleOptions)],
   parserOptions: {sourceType: 'module'}
 });
 
@@ -37,7 +37,8 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
       'function foo(bar) {bar(); return bar()}',
       'class MyClass { foo(bar) {bar(); return bar()} }',
       'var MyClass = { foo(bar) {bar(); return bar()} }',
-      'export default function xyz() { return 3; }'
+      'export default function xyz() { return 3; }',
+      'class MyClass { render(a, b) { return 3; } }'
     ].map(singleReturnOnly)
   ],
   invalid: [
@@ -48,7 +49,7 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
     {code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};', errors: ['Prefer using arrow functions over plain functions'], options: [{disallowPrototype:true}]},
     ...[
       // Make sure it works with ES6 classes & functions declared in object literals
-      ['class MyClass { render(a, b) { return 3; } }', 'class MyClass { render = (a, b) => 3; }'],
+      ['class MyClass { render(a, b) { return 3; } }', 'class MyClass { render = (a, b) => 3; }', {classPropertiesAllowed: true}],
       ['var MyClass = { render(a, b) { return 3; }, b: false }', 'var MyClass = { render: (a, b) => 3, b: false }'],
 
       // Make sure named function declarations work
@@ -95,7 +96,7 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
         errors: ['Prefer using arrow functions over plain functions which only return a value'],
         output: inputOutput[1]
       },
-      singleReturnOnly(inputOutput[0])
+      singleReturnOnly(inputOutput[0], inputOutput[2])
     ))
   ]
 });


### PR DESCRIPTION
Allow autofixing using `eslint --fix` for `singleReturnOnly` mode.

I ran this on one of our codebases here at Uber with 35 kloc and it successfully converted 450+ functions into arrow functions.

The code is unfortunately pretty confusing because eslint has a bad API for AST manipulation :) So I had to roll something myself and it's a little messy