### PR TITLE
Allow functions with reference to 'this'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # eslint-plugin-prefer-arrow
-ESLint plugin to prefer arrow functions. By default, the plugin allows usage of `function` as a member of an Object's prototype, but this can be changed with the property `disallowPrototype`. Alternatively, with the `singleReturnOnly` option, this plugin only reports functions where converting to an arrow function would dramatically simplify the code.
+ESLint plugin to prefer arrow functions. By default, the plugin allows usage of `function` as a member of an Object's prototype, but this can be changed with the property `disallowPrototype`. Functions referencing `this` will also be allowed. Alternatively, with the `singleReturnOnly` option, this plugin only reports functions where converting to an arrow function would dramatically simplify the code.
 
 This plugin will automatically fix your code using ESLint's `--fix` option, as long as you use the `singleReturnOnly` option.
 

--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -65,6 +65,20 @@ const isConstructor = (node) => {
   return parent && parent.kind === 'constructor';
 }
 
+const containsThis = (node) => {
+  if (typeof node !== 'object' || node === null) return false;
+  if (node.type === 'ThisExpression') return true;
+  return Object.keys(node).some(field => {
+    if (field === 'parent') {
+      return false;
+    }
+    else if (Array.isArray(node[field])) {
+      return node[field].some(containsThis);
+    }
+    return containsThis(node[field]);
+  });
+}
+
 const isNamed = (node) =>
   node.type === 'FunctionDeclaration' && node.id && node.id.name;
 
@@ -79,6 +93,7 @@ const isClassMethod = node => node.parent.type === 'MethodDefinition';
 const inspectNode = (node, context) => {
   const opts = context.options[0] || {};
   if(isConstructor(node)) return;
+  if(containsThis(node)) return;
   if (opts.singleReturnOnly) {
     if (functionOnlyContainsReturnStatement(node) && !isNamedDefaultExport(node)
         && (opts.classPropertiesAllowed || !isClassMethod(node)))

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -27,6 +27,7 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
     'var foo = (...args) => args',
     'class obj {constructor(foo){this.foo = foo;}}; obj.prototype.func = function() {};',
     'class obj {constructor(foo){this.foo = foo;}}; obj.prototype = {func: function() {}};',
+    'var foo = function() { return this.bar; };',
     ...[
       'var foo = (bar) => {return bar();}',
       'function foo(bar) {bar()}',


### PR DESCRIPTION
Great plugin :+1: - the extra functionality I need is where the function in question uses `this`, they cannot be easily converted to arrows and should be ignored by this rule.

If you'd prefer I set it up as a config prop, just say so and I will, but I think there aren't cases where anyone would want to disable it I think.

I've included a test too.