### PR TITLE
Add support for ESLint 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "author": "Triston Jones <contact@tristonjones.com>",
   "license": "MIT",
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0"
+    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0",
+    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "mocha": "^3.4.1"
   },
   "keywords": [


### PR DESCRIPTION
This plugin works fine with ESLint 4 but is not explicitly included in the dev nor peer dependencies list, causing npm warnings. This PR just adds version 4 to the lists to suppress the warnings.

Please consider merging and publishing a new package. Thanks!!