### PR TITLE
Fix for class methods with reference to `this`

### DIFF
--- a/lib/rules/prefer-arrow-functions.js
+++ b/lib/rules/prefer-arrow-functions.js
@@ -123,7 +123,7 @@ const inspectNode = (node, context) => {
   const opts = context.options[0] || {};
 
   if(isConstructor(node)) return;
-  if(containsThis(node)) return;
+  if(containsThis(node) && !isClassMethod(node)) return;
   if(isGeneratorFunction(node)) return;
   if(isGetterOrSetter(node)) return;
   if(isClassMethod(node) && !opts.classPropertiesAllowed) return;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@typescript-eslint/parser": "^2.4.0",
     "babel-eslint": "^10.0.3",
-    "eslint": ">=2.0.0",
+    "eslint": ">=2.0.0 <7.0.0",
     "mocha": "^3.4.1",
     "typescript": "^3.6.4"
   },

--- a/test/lib/rules/prefer-arrow-functions.js
+++ b/test/lib/rules/prefer-arrow-functions.js
@@ -82,6 +82,12 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
       code: 'function foo(a: string): string { return `bar ${a}`;}',
       options: [{ allowStandaloneDeclarations: true }],
       parser: require.resolve('@typescript-eslint/parser')
+    },
+
+    {
+      code: 'class MyClass { constructor() { this.x = 0; } add = (y) => { this.x += y; }; }',
+      options: [{ classPropertiesAllowed: true }],
+      parser: require.resolve('babel-eslint')
     }
   ],
   invalid: [
@@ -257,6 +263,13 @@ tester.run('lib/rules/prefer-arrow-functions', rule, {
           ...((inputOutput[3] || {}).parserOptions || {})
         },
       }
-    ))
+    )),
+
+    {
+      code: 'class MyClass { constructor() { this.x = 0; } add(y) { this.x += y; } }',
+      errors: ['Prefer using arrow functions over plain functions'],
+      options: [{ classPropertiesAllowed: true }],
+      parser: require.resolve('babel-eslint')
+    }
   ]
 });


### PR DESCRIPTION
Fixes #19 

It appears that ever since #4 was merged, the plugin no longer shows errors for class methods with reference to `this` when "classPropertiesAllowed" is set to `true`, because it only checks if a function has reference to `this`, and not if the function is also a class method. This PR fixes that.